### PR TITLE
GET events (with pagination)

### DIFF
--- a/docs/createEventsTable.sql
+++ b/docs/createEventsTable.sql
@@ -1,0 +1,29 @@
+-- Table: public."Events"
+
+-- DROP TABLE public."Events";
+
+CREATE TABLE public."Events"
+(
+  "eventId" SERIAL PRIMARY KEY,
+  "name" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "description" character varying(200) COLLATE pg_catalog."default",
+  "address" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "address2" character varying(50) COLLATE pg_catalog."default",
+  "city" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "state" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "zip" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "country" character varying(50) NOT NULL COLLATE pg_catalog."default",
+  "gpsLocation" GEOGRAPHY,
+  "startDate" timestamp with time zone NOT NULL,
+  "endDate" timestamp with time zone NOT NULL,
+  "status" character varying(10) COLLATE pg_catalog."default",
+  "createdBy" integer NOT NULL,
+  "createdOn" timestamp with time zone NOT NULL,
+  "lastUpdated" timestamp with time zone NOT NULL,
+  FOREIGN KEY ("createdBy") REFERENCES public."Users" ("userId")
+)
+WITH (
+  OIDS=FALSE
+);
+ALTER TABLE public."Events"
+  OWNER TO "postgres";

--- a/docs/installExtensions.sql
+++ b/docs/installExtensions.sql
@@ -1,0 +1,2 @@
+-- PostGIS
+CREATE EXTENSION postgis;

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,7 +88,7 @@ app.get(`/${prefix}/users`, UserRouter.getAll);
 app.post(`/${prefix}/signUp`, UserRouter.signUp)
 
 // Events
-app.get(`/${prefix}/events`, requireSignIn, EventRouter.getEvents)
+app.get(`/${prefix}/events`, EventRouter.getEvents)
 
 // Default Route requires authorization
 const router = express.Router();

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import * as passport from 'passport';
 import * as passportJwt from 'passport-jwt'
 import * as LocalStrategy from 'passport-local'
 
+import { EventRouter } from './routes/EventRouter';
 import { UserRouter } from './routes/UserRouter';
 import { AppConstants } from './utils/AppConstants';
 import { envConfig } from './utils/envConfig'; // Environment-specific configuration
@@ -87,6 +88,7 @@ app.get(`/${prefix}/users`, UserRouter.getAll);
 app.post(`/${prefix}/signUp`, UserRouter.signUp)
 
 // Events
+app.get(`/${prefix}/events`, requireSignIn, EventRouter.getEvents)
 
 // Default Route requires authorization
 const router = express.Router();

--- a/src/interfaces/database/IDBEvent.ts
+++ b/src/interfaces/database/IDBEvent.ts
@@ -1,0 +1,19 @@
+export interface IDBEvent {
+  eventId: number;
+  name: string;
+  description: string;
+  address: string;
+  address2: string;
+  city: string;
+  state: string;
+  zip: string;
+  country: string;
+  latitude: string;
+  longitude: string;
+  startDate: Date;
+  endDate: Date;
+  status: string; // TODO Define an enum/type for event status
+  createdBy: number;
+  createdOn: Date;
+  lastUpdated: Date;
+}

--- a/src/interfaces/response/IEventResponse.ts
+++ b/src/interfaces/response/IEventResponse.ts
@@ -1,0 +1,23 @@
+export interface IEventResponse {
+  eventId: number;
+  name: string;
+  description: string;
+  address: {
+    line1: string;
+    line2: string;
+    city: string;
+    state: string;
+    zip: string;
+    country: string;
+    coordinates: {
+      latitude: string;
+      longitude: string;
+    }
+  };
+  startDate: Date;
+  endDate: Date;
+  status: string; // TODO Define an enum/type for event status
+  createdBy: number;
+  createdOn: Date;
+  lastUpdated: Date;
+}

--- a/src/interfaces/response/IPaginatedResponse.ts
+++ b/src/interfaces/response/IPaginatedResponse.ts
@@ -1,0 +1,9 @@
+import { IPagination } from './IPagination'
+
+export interface IPaginatedResponse<T> {
+  pagination: IPagination;
+  events?: T[];
+  items?: T[];
+  users?: T[];
+  threads?: T[];
+}

--- a/src/interfaces/response/IPagination.ts
+++ b/src/interfaces/response/IPagination.ts
@@ -1,0 +1,6 @@
+export interface IPagination {
+  currentPage: number;
+  totalPages: number;
+  numItems: number;
+  pageSize: number;
+}

--- a/src/routes/EventRouter.ts
+++ b/src/routes/EventRouter.ts
@@ -30,6 +30,4 @@ export class EventRouter {
     EventService.getEvents(pageNum, pageSize)
       .then(paginatedEventResponse => res.json(paginatedEventResponse))
   }
-
-  private static MAX_PAGE_SIZE = 100;
 }

--- a/src/routes/EventRouter.ts
+++ b/src/routes/EventRouter.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from 'express';
+import { EventService } from '../services/EventService';
+import { AppConstants } from '../utils/AppConstants';
+
+export class EventRouter {
+
+
+  public static getEvents(req: Request, res: Response, next: NextFunction) {
+    let pageNum: number = AppConstants.DEFAULT_PAGE_NUM
+    let pageSize: number = AppConstants.DEFAULT_PAGE_SIZE;
+
+    if (req.query) {
+      const parsedPageNum = Number.parseInt(req.query.page)
+      if (parsedPageNum) {
+        pageNum = parsedPageNum
+      }
+
+      const parsedPageSize = Number.parseInt(req.query.size)
+      if (parsedPageSize) {
+        pageSize = parsedPageSize
+      }
+    }
+
+    if (pageSize > AppConstants.DEFAULT_MAX_PAGE_SIZE) {
+      pageSize = AppConstants.DEFAULT_MAX_PAGE_SIZE
+    } else if (pageSize < AppConstants.DEFAULT_MIN_PAGE_SIZE) {
+      pageSize = AppConstants.DEFAULT_MIN_PAGE_SIZE
+    }
+
+    EventService.getEvents(pageNum, pageSize)
+      .then(paginatedEventResponse => res.json(paginatedEventResponse))
+  }
+
+  private static MAX_PAGE_SIZE = 100;
+}

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -1,0 +1,46 @@
+import { db } from '../database';
+import { IEventResponse } from '../interfaces/response/IEventResponse';
+import { IPaginatedResponse } from '../interfaces/response/IPaginatedResponse';
+import { PaginationUtil } from '../utils/PaginationUtil';
+
+export class EventService {
+
+  public static getEvents(pageNum: number, pageSize: number): Promise<IPaginatedResponse<IEventResponse>> {
+    const rowCountPromise = db.one<{ numEvents: number }>(`SELECT
+    count(*) as "numEvents" FROM public."Events"`)
+      .then(data => data.numEvents);
+
+    const eventsPromise = db.many<{ event: IEventResponse }>(`SELECT json_build_object(
+      'eventId', e."eventId",
+      'name', e."name",
+      'description', e."description",
+      'address', json_build_object(
+        'line1', e."address",
+        'line2', e."address2",
+        'city', e."city",
+        'state', e."state",
+        'zip', e."zip",
+        'country', e."country",
+        'coordinates', json_build_object(
+          'latitude', ST_Y(e."gpsLocation"::geometry)::float,
+          'longitude', ST_X(e."gpsLocation"::geometry)::float
+        )
+      ),
+      'startDate', e."startDate",
+      'endDate', e."endDate",
+      'status', e."status",
+      'createdBy', e."createdBy",
+      'createdOn', e."createdOn",
+      'lastUpdated', e."lastUpdated") as event
+      FROM public."Events" e
+      LIMIT $1 OFFSET $2`, [pageSize, (pageSize * (pageNum - 1))])
+      .then(eventsArr => eventsArr.map(it => it.event));
+
+    return Promise.all([rowCountPromise, eventsPromise])
+      .then(allResponses => {
+        const [numItems, events] = allResponses
+
+        return PaginationUtil.createPaginatedResponse(events, 'events', pageNum, pageSize, numItems);
+      })
+  }
+}

--- a/src/utils/AppConstants.ts
+++ b/src/utils/AppConstants.ts
@@ -1,4 +1,8 @@
 export class AppConstants {
 
   public static API_VERSION = 1;
+  public static DEFAULT_PAGE_NUM = 1;
+  public static DEFAULT_PAGE_SIZE = 20;
+  public static DEFAULT_MAX_PAGE_SIZE = 100;
+  public static DEFAULT_MIN_PAGE_SIZE = 1;
 }

--- a/src/utils/PaginationUtil.ts
+++ b/src/utils/PaginationUtil.ts
@@ -1,0 +1,28 @@
+import { IPaginatedResponse } from '../interfaces/response/IPaginatedResponse';
+import { IPagination } from '../interfaces/response/IPagination';
+
+type KNOWN_KEYS_TYPE = 'items' | 'events' | 'threads' | 'posts' | 'users'
+const KNOWN_KEYS = ['items', 'events', 'threads', 'posts', 'users'];
+
+export class PaginationUtil {
+
+  public static createPaginatedResponse<T>(pageItems: T[], key: KNOWN_KEYS_TYPE, pageNum: number, pageSize: number, totalNumItems: number): IPaginatedResponse<T> {
+    if (!KNOWN_KEYS.includes(key)) {
+      throw new Error(`${key} is not a known pagination key. Must be one of: ${KNOWN_KEYS.join(', ')}`);
+    }
+
+    return {
+      [key]: pageItems,
+      pagination: PaginationUtil.createPagination(pageNum, pageSize, totalNumItems)
+    }
+  }
+
+  public static createPagination(pageNum: number, pageSize: number, totalNumItems: number): IPagination {
+    return {
+      currentPage: pageNum,
+      numItems: totalNumItems,
+      pageSize,
+      totalPages: Math.ceil(totalNumItems / pageSize)
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2016",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Overview:
**Request**
The /events endpoint returns a paginated set of events. By default, it returns the first page of events, with 20 events per page. The request takes two optional query parameters, `page`, that specifies the page of events being requested, and `size`, the number of events per page.

**Response**
The response contains an array of events and pagination information
```json
{
  "events": [ ... ],
  "pagination": {
    "currentPage": 1,
    "totalPages": 5,
    "numItems": 100,
    "pageSize": 20
  }
}
```